### PR TITLE
Add support for parsing more accelerate launch params

### DIFF
--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -72,8 +72,11 @@ def main():
                     accelerate_launch_args.extend([f"--{key}", str(param_val)])
             else:
                 accelerate_launch_args.append(f"--{key}")
-                # For flags that don't have value, ie. --quiet, only add if value is true
-                if actions_type_map.get(key) not in ["_StoreTrueAction", "_StoreFalseAction"]:
+                # Only need to add key for params that aren't flags ie. --quiet
+                if actions_type_map.get(key) not in [
+                    "_StoreTrueAction",
+                    "_StoreFalseAction",
+                ]:
                     accelerate_launch_args.append(str(val))
 
         if json_configs.get("multi_gpu"):

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -73,10 +73,7 @@ def main():
             else:
                 accelerate_launch_args.append(f"--{key}")
                 # Only need to add key for params that aren't flags ie. --quiet
-                if actions_type_map.get(key) not in [
-                    "_StoreTrueAction",
-                    "_StoreFalseAction",
-                ]:
+                if actions_type_map.get(key) == "_StoreAction":
                     accelerate_launch_args.append(str(val))
 
         if json_configs.get("multi_gpu"):

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -57,10 +57,9 @@ def main():
 
     parser = launch_command_parser()
     # determine which flags are store true actions (don't require a value to be set)
-    store_action_params = {}
-    for action in parser._actions:
-        if type(action).__name__ == "_StoreTrueAction":
-            store_action_params[action.dest] = action
+    actions_type_map = {
+        action.dest: type(action).__name__ for action in parser._actions
+    }
 
     # parse accelerate_launch_args
     accelerate_launch_args = []
@@ -68,12 +67,14 @@ def main():
     if accelerate_config:
         logging.info("Using accelerate_launch_args configs: %s", accelerate_config)
         for key, val in accelerate_config.items():
-            # For flags that don't have value, ie. --quiet, only add if value is true
-            if store_action_params.get(key) and val:
-                accelerate_launch_args.append(f"--{key}")
+            if actions_type_map.get(key) == "_AppendAction":
+                for param_val in val:
+                    accelerate_launch_args.extend([f"--{key}", str(param_val)])
             else:
                 accelerate_launch_args.append(f"--{key}")
-                accelerate_launch_args.append(str(val))
+                # For flags that don't have value, ie. --quiet, only add if value is true
+                if actions_type_map.get(key) not in ["_StoreTrueAction", "_StoreFalseAction"]:
+                    accelerate_launch_args.append(str(val))
 
         if json_configs.get("multi_gpu"):
             # add FSDP config


### PR DESCRIPTION
Covering the action types that are used for `accelerate launch` params, we can extend this later for others later


Tested with:
```
{
    "accelerate_launch_args": {
      "use_fsdp": true,
      "env": ["env1", 1, "env2"],
      "dynamo_use_dynamic": true,
      "num_machines": 1,
      "num_processes":2,
      "main_process_port": 1234,
      "fsdp_backward_prefetch_policy": "TRANSFORMER_BASED_WRAP",
      "fsdp_sharding_strategy": 1,
      "fsdp_state_dict_type": "FULL_STATE_DICT",
      "fsdp_cpu_ram_efficient_loading": true,
      "fsdp_sync_module_states": true,
      "config_file": "fixtures/accelerate_fsdp_defaults.yaml"
    },
    "multi_gpu": true,
    "model_name_or_path": "dummy_model",
    "training_data_path": "twitter_complaints.json",
    "output_dir": "output_twitter",
    "num_train_epochs": 5.0,
    "per_device_train_batch_size": 4,
    "per_device_eval_batch_size": 4,
    "gradient_accumulation_steps": 4,
    "save_strategy": "epoch",
    "learning_rate": 0.03,
    "weight_decay": 0.000001,
    "lr_scheduler_type": "cosine",
    "logging_steps": 1.0,
    "packing": false,
    "include_tokens_per_second": true,
    "response_template": "### Label:",
    "dataset_text_field": "output",
    "use_flash_attn": false,
    "torch_dtype": "bfloat16",
    "tokenizer_name_or_path": "dummy_model"
  }
```